### PR TITLE
Patch with defaults

### DIFF
--- a/src/exchanges/crdtExchange.ts
+++ b/src/exchanges/crdtExchange.ts
@@ -205,6 +205,11 @@ const patchExtractor: PatchExtractorConfig = {
   },
 };
 
+const applyInspectionDefaults = produce((draft) => {
+  draft.areas = draft.areas || []
+  draft.areas.forEach((area: any) => area.items = area.items || [])
+})
+
 // TODO: better naming, allow as an option
 // handle GetInspection
 // this doesn't handle fields that need a default, for instance, areas[n].items = []
@@ -242,12 +247,15 @@ const queryUpdater: QueryUpdaterConfig = {
       inspection && newInspections.push(inspection);
     }
 
+    let allInspections = [...newInspections, ...patchedInspections];
+    allInspections = allInspections.map(applyInspectionDefaults);
+
     return {
       result: makeResult(result.operation, {
         ...result,
         data: {
           ...result.data,
-          allInspections: [...newInspections, ...patchedInspections],
+          allInspections,
         },
       }),
     };
@@ -272,7 +280,8 @@ const queryUpdater: QueryUpdaterConfig = {
       key,
       data: inspection
     });
-    const newInspection = patchedCrdtStore.get(serializedKey);
+    let newInspection = patchedCrdtStore.get(serializedKey);
+    newInspection = applyInspectionDefaults(newInspection);
 
     return {
       result: makeResult(result.operation, {


### PR DESCRIPTION
By supporting this patch mutation style, all input variables of the mutation are
optional to allow sending the minimal set of changes per mutation.

This causes a potential problem with optimistic mutations where certain required
result fields may not have been populated. (ex: not sending an array of areas when
there are no areas to be made).

This current implementation currently only places defaults for array subtypes,
but more defaults could easily be added. It is also purely config based.